### PR TITLE
[bug] [ERROR] Error: Typed property Hyperf\Kafka\AbstractConsumer::$m…

### DIFF
--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -64,7 +64,7 @@ abstract class AbstractConsumer
 
     public function getMemberId(): ?string
     {
-        return $this->memberId;
+        return $this->memberId ?? null;
     }
 
     public function setMemberId(?string $memberId): void


### PR DESCRIPTION
[bug] [ERROR] Error: Typed property Hyperf\Kafka\AbstractConsumer::$memberId must not be accessed before initialization

当没设置memberId时 , 会报错