### PR TITLE
Add retry configuration for Kafka producer

### DIFF
--- a/publish/kafka.php
+++ b/publish/kafka.php
@@ -28,6 +28,10 @@ return [
         'acks' => -1,
         'producer_id' => -1,
         'producer_epoch' => -1,
+        'produce' => [
+            'retry' => 3,
+            'retry_sleep' => 0.1,
+        ],
         'partition_leader_epoch' => -1,
         'interval' => 0,
         'session_timeout' => 60,

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -172,6 +172,8 @@ class Producer
         $producerConfig->setAcks($config['acks']);
         $producerConfig->setProducerId($config['producer_id']);
         $producerConfig->setProducerEpoch($config['producer_epoch']);
+        $producerConfig->setProduceRetry($config['produce']['retry']);
+        $producerConfig->setProduceRetrySleep($config['produce']['retry_sleep']);
         $producerConfig->setPartitionLeaderEpoch($config['partition_leader_epoch']);
         $producerConfig->setAutoCreateTopic($config['auto_create_topic']);
         ! empty($config['sasl']) && $producerConfig->setSasl($config['sasl']);


### PR DESCRIPTION
### Changed

This PR introduces support for configuring retry behavior in the Kafka producer by adding two new options:
`produce.retry`: Number of times to retry sending a message if it initially fails.
`produce.retry_sleep`: Time to wait (in seconds) between each retry attempt.

These values are injected into the producer via two new setter methods:
`setProduceRetry(int $times)`
`setProduceRetrySleep(float $seconds)`